### PR TITLE
fix: zsh post date fixes #9

### DIFF
--- a/blog/posts/oh-my-zsh-setup/index.qmd
+++ b/blog/posts/oh-my-zsh-setup/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "'Jazzing Up' `zsh` with `oh-my-zsh`"
 description: "How to set-up `oh-my-zsh` with some helpful plugins and themes."
-date: 06/05/2024
+date: 05/06/2024
 date-modified: last-modified
 date-format: iso
 layout: post


### PR DESCRIPTION
Fixes #9 - caused by American date format. Corrected to right date.